### PR TITLE
Update power_profile.xml

### DIFF
--- a/overlay/frameworks/base/core/res/res/xml/power_profile.xml
+++ b/overlay/frameworks/base/core/res/res/xml/power_profile.xml
@@ -1,29 +1,80 @@
 <?xml version="1.0" encoding="utf-8"?>
-<device name="Android">
-    <item name="screen.on">63</item>
-    <item name="screen.full">261</item>
-    <item name="wifi.on">0.1</item>
-    <item name="wifi.active">0.1</item>
-    <item name="wifi.scan">0.1</item>
-    <array name="cpu.speeds">
-        <value>652800</value>
-        <value>1036800</value>
-        <value>1401600</value>
-        <value>1689600</value>
-        <value>1843200</value>
-        <value>1958400</value>
-        <value>2016000</value>
-    </array>
-    <array name="cpu.active">
-        <value>151</value>
-        <value>169</value>
-        <value>177</value>
-        <value>195</value>
-        <value>259</value>
-        <value>307</value>
-        <value>353</value>
-    </array>
-    <item name="cpu.awake">1.6</item>
-    <item name="cpu.idle">1.6</item>
-    <item name="battery.capacity">4100</item>
+<!--
+**
+** Copyright 2009, The Android Open Source Project
+**
+** Licensed under the Apache License, Version 2.0 (the "License")
+** you may not use this file except in compliance with the License.
+** You may obtain a copy of the License at
+**
+**     http://www.apache.org/licenses/LICENSE-2.0
+**
+** Unless required by applicable law or agreed to in writing, software
+** distributed under the License is distributed on an "AS IS" BASIS,
+** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+** See the License for the specific language governing permissions and
+** limitations under the License.
+*/
+-->
+
+<device name="markw">
+  <!-- Most values are the incremental current used by a feature,
+       in mA (measured at nominal voltage).
+       The default values are deliberately incorrect dummy values.
+       OEM's must measure and provide actual values before
+       shipping a device.
+       Example real-world values are given in comments, but they
+       are totally dependent on the platform and can vary
+       significantly, so should be measured on the shipping platform
+       with a power meter. -->
+  <item name="none">0</item>
+  <item name="screen.on">63</item>  <!-- ~200mA -->
+  <item name="screen.full">261</item>  <!-- ~300mA -->
+  <item name="bluetooth.active">10</item> <!-- Bluetooth data transfer, ~10mA -->
+  <item name="bluetooth.on">0.78</item>  <!-- Bluetooth on & connectable, but not connected, ~0.1mA -->
+  <item name="wifi.on">0.65</item>  <!-- ~3mA -->
+  <item name="wifi.active">180</item>  <!-- WIFI data transfer, ~200mA -->
+  <item name="wifi.scan">130</item>  <!-- WIFI network scanning, ~100mA -->
+  <item name="dsp.audio">46</item> <!-- ~10mA -->
+  <item name="dsp.video">65</item> <!-- ~50mA -->
+  <item name="camera.flashlight">160</item> <!-- Avg. power for camera flash, ~160mA -->
+  <item name="camera.avg">521.80</item> <!-- Avg. power use of camera in standard usecases, ~550mA -->
+  <item name="radio.active">134.84</item> <!-- ~200mA -->
+  <item name="radio.scanning">10</item> <!-- cellular radio scanning for signal, ~10mA -->
+  <item name="gps.on">68.84</item> <!-- ~50mA -->
+  </array>
+  <!-- Different CPU speeds as reported in
+       /sys/devices/system/cpu/cpu0/cpufreq/stats/time_in_state -->
+  <array name="cpu.speeds">
+      <value>400457</value> <!-- 400 MHz CPU speed -->
+      <value>652800</value> <!-- 625 MHz CPU speed -->
+      <value>806400</value> <!-- 806 MHz CPU speed -->
+      <value>1036800</value> <!-- 1036 MHz CPU speed -->
+      <value>1209600</value> <!-- 1209 MHz CPU speed -->
+      <value>1401600</value> <!-- 1401 MHz CPU speed -->
+      <value>1689600</value> <!-- 1689 MHz CPU speed -->
+      <value>1804800</value> <!-- 1804 MHz CPU speed -->
+      <value>1958400</value> <!-- 1958 MHz CPU speed -->
+      <value>2016000</value> <!-- 2016 MHz CPU speed -->
+      <value>2150400</value> <!-- 2150 MHz CPU speed -->
+      <value>2208000</value> <!-- 2208 MHz CPU speed -->
+  <!-- Current when CPU is idle -->
+  <item name="cpu.idle">3</item>
+  <!-- Current at each CPU speed, as per 'cpu.speeds' -->
+  <array name="cpu.active">
+      <value>146</value>
+      <value>151</value>
+      <value>157</value>
+      <value>163</value>
+      <value>170</value>
+      <value>177</value>
+      <value>195</value>
+      <value>259</value>
+      <value>307</value>
+      <value>353</value>
+      <value>395</value>
+      <value>445</value>
+  </array>
+  <!-- This is the battery capacity in mAh (measured at nominal voltage) -->
+  <item name="battery.capacity">4100</item>
 </device>

--- a/overlay/frameworks/base/core/res/res/xml/power_profile.xml
+++ b/overlay/frameworks/base/core/res/res/xml/power_profile.xml
@@ -28,20 +28,20 @@
        significantly, so should be measured on the shipping platform
        with a power meter. -->
   <item name="none">0</item>
-  <item name="screen.on">63</item>  <!-- ~200mA -->
-  <item name="screen.full">261</item>  <!-- ~300mA -->
+  <item name="screen.on">63</item>  <!-- screen is turned on at minimum brightness, ~200mA -->
+  <item name="screen.full">261</item>  <!-- screen is at maximum brightness, compared to screen at minimum brightness, ~300mA -->
   <item name="bluetooth.active">10</item> <!-- Bluetooth data transfer, ~10mA -->
   <item name="bluetooth.on">0.78</item>  <!-- Bluetooth on & connectable, but not connected, ~0.1mA -->
-  <item name="wifi.on">0.65</item>  <!-- ~3mA -->
+  <item name="wifi.on">0.65</item>  <!-- Wi-Fi is turned on but not receiving, transmitting, or scanning, ~2mA -->
   <item name="wifi.active">180</item>  <!-- WIFI data transfer, ~200mA -->
   <item name="wifi.scan">130</item>  <!-- WIFI network scanning, ~100mA -->
-  <item name="dsp.audio">46</item> <!-- ~10mA -->
-  <item name="dsp.video">65</item> <!-- ~50mA -->
-  <item name="camera.flashlight">160</item> <!-- Avg. power for camera flash, ~160mA -->
+  <item name="dsp.audio">46</item> <!-- audio decoding/encoding via DSP, ~14.1mA -->
+  <item name="dsp.video">65</item> <!-- video decoding via DSP, ~54mA -->
+  <item name="camera.flashlight">160</item> <!-- Avg. power for camera flash, ~200mA -->
   <item name="camera.avg">521.80</item> <!-- Avg. power use of camera in standard usecases, ~550mA -->
-  <item name="radio.active">134.84</item> <!-- ~200mA -->
+  <item name="radio.active">134.84</item> <!-- cellular radio is transmitting/receiving, ~100-300mA -->
   <item name="radio.scanning">10</item> <!-- cellular radio scanning for signal, ~10mA -->
-  <item name="gps.on">68.84</item> <!-- ~50mA -->
+  <item name="gps.on">68.84</item> <!-- GPS is acquiring a signal, ~50mA -->
   </array>
   <!-- Different CPU speeds as reported in
        /sys/devices/system/cpu/cpu0/cpufreq/stats/time_in_state -->
@@ -58,8 +58,7 @@
       <value>2016000</value> <!-- 2016 MHz CPU speed -->
       <value>2150400</value> <!-- 2150 MHz CPU speed -->
       <value>2208000</value> <!-- 2208 MHz CPU speed -->
-  <!-- Current when CPU is idle -->
-  <item name="cpu.idle">3</item>
+  </array>
   <!-- Current at each CPU speed, as per 'cpu.speeds' -->
   <array name="cpu.active">
       <value>146</value>
@@ -75,6 +74,10 @@
       <value>395</value>
       <value>445</value>
   </array>
+  <!-- Total power drawn by the system when CPUs (and the SoC) are in system suspend state. -->
+  <item name="cpu.idle">3</item>
+  <!-- CPUs are in scheduling idle state (kernel idle loop); system is not in system suspend state. -->
+  <item name="cpu.awake">3</item> 
   <!-- This is the battery capacity in mAh (measured at nominal voltage) -->
   <item name="battery.capacity">4100</item>
 </device>

--- a/overlay/frameworks/base/core/res/res/xml/power_profile.xml
+++ b/overlay/frameworks/base/core/res/res/xml/power_profile.xml
@@ -35,12 +35,12 @@
   <item name="wifi.on">0.65</item>  <!-- Wi-Fi is turned on but not receiving, transmitting, or scanning, ~2mA -->
   <item name="wifi.active">180</item>  <!-- WIFI data transfer, ~200mA -->
   <item name="wifi.scan">130</item>  <!-- WIFI network scanning, ~100mA -->
-  <item name="dsp.audio">46</item> <!-- audio decoding/encoding via DSP, ~14.1mA -->
-  <item name="dsp.video">65</item> <!-- video decoding via DSP, ~54mA -->
+  <item name="dsp.audio">11.9</item> <!-- audio decoding/encoding via DSP, ~14.1mA -->
+  <item name="dsp.video">56.87</item> <!-- video decoding via DSP, ~54mA -->
   <item name="camera.flashlight">240</item> <!-- Avg. power for camera flash, ~200mA -->
-  <item name="camera.avg">521.80</item> <!-- Avg. power use of camera in standard usecases, ~550mA -->
-  <item name="radio.active">134.84</item> <!-- cellular radio is transmitting/receiving, ~100-300mA -->
-  <item name="radio.scanning">10</item> <!-- cellular radio scanning for signal, ~10mA -->
+  <item name="camera.avg">521.8</item> <!-- Avg. power use of camera in standard usecases, ~550mA -->
+  <item name="radio.active">231.8</item> <!-- cellular radio is transmitting/receiving, ~100-300mA -->
+  <item name="radio.scanning">34.2</item> <!-- cellular radio scanning for signal, ~10mA -->
   <item name="gps.on">68.84</item> <!-- GPS is acquiring a signal, ~50mA -->
   </array>
   <!-- Different CPU speeds as reported in
@@ -61,23 +61,23 @@
   </array>
   <!-- Current at each CPU speed, as per 'cpu.speeds' -->
   <array name="cpu.active">
-      <value>146</value>
-      <value>151</value>
-      <value>157</value>
-      <value>163</value>
-      <value>170</value>
-      <value>177</value>
-      <value>195</value>
-      <value>259</value>
-      <value>307</value>
-      <value>353</value>
-      <value>395</value>
-      <value>445</value>
+      <value>22.4</value>
+      <value>34.3</value>
+      <value>45.2</value>
+      <value>47.0</value>
+      <value>67.7</value>
+      <value>60.0</value>
+      <value>76.0</value>
+      <value>90.0</value>
+      <value>106.6</value>
+      <value>113.6</value>
+      <value>120.4</value>
+      <value>123.7</value>
   </array>
   <!-- Total power drawn by the system when CPUs (and the SoC) are in system suspend state. -->
-  <item name="cpu.idle">3</item>
+  <item name="cpu.idle">4.9</item>
   <!-- CPUs are in scheduling idle state (kernel idle loop); system is not in system suspend state. -->
-  <item name="cpu.awake">3</item> 
+  <item name="cpu.awake">8.1</item> 
   <!-- This is the battery capacity in mAh (measured at nominal voltage) -->
   <item name="battery.capacity">4100</item>
 </device>

--- a/overlay/frameworks/base/core/res/res/xml/power_profile.xml
+++ b/overlay/frameworks/base/core/res/res/xml/power_profile.xml
@@ -37,7 +37,7 @@
   <item name="wifi.scan">130</item>  <!-- WIFI network scanning, ~100mA -->
   <item name="dsp.audio">46</item> <!-- audio decoding/encoding via DSP, ~14.1mA -->
   <item name="dsp.video">65</item> <!-- video decoding via DSP, ~54mA -->
-  <item name="camera.flashlight">160</item> <!-- Avg. power for camera flash, ~200mA -->
+  <item name="camera.flashlight">240</item> <!-- Avg. power for camera flash, ~200mA -->
   <item name="camera.avg">521.80</item> <!-- Avg. power use of camera in standard usecases, ~550mA -->
   <item name="radio.active">134.84</item> <!-- cellular radio is transmitting/receiving, ~100-300mA -->
   <item name="radio.scanning">10</item> <!-- cellular radio scanning for signal, ~10mA -->


### PR DESCRIPTION
It is based on the data given below, due to the fact that the manufacturer was too lazy to measure the currents.
https://source.android.com/devices/tech/power/values
https://github.com/rohantaneja/android_device_xiaomi_tissot/blob/79d8b918df4e28f8d85eefa553836d490c074693/overlay/frameworks/base/core/res/res/xml/power_profile.xml
https://github.com/skinzor/android_device_huawei_can/blob/cm13.0/overlay/frameworks/base/core/res/res/xml/power_profile.xml
https://github.com/xuefer/android_device_xiaomi_oxygen/blob/cm-14.1/overlay/frameworks/base/core/res/res/xml/power_profile.xml